### PR TITLE
Update flink connector to the 0.8 latest snapshot

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ slf4jApiVersion=1.7.25
 # For Flink 1.10, SDP 1.1
 flinkShortVersion=1.10
 flinkVersion=1.10.0
-pravegaFlinkConnectorVersion=0.7.1-53.fd81ff2-SNAPSHOT
+pravegaFlinkConnectorVersion=0.8.0-53.a3e3d8d-SNAPSHOT
 
 # Set below to true when using Pravega in SDP.
 includePravegaCredentials=true


### PR DESCRIPTION
This PR implements the change to flink connector version to **0.8.0-53.a3e3d8d-SNAPSHOT**

Tested the change by building the jar `./gradlew clean shadowJar` and confirmed the connector version.
```
> Resolve files of :flink-tools:flinkShadowJar > pravega-connectors-flink-1.10_2.12-0.8.0-53.a3e3d8d-20200828.093539-1.jar > 14.95 MB/16.74 MB downloaded
```

```
$ ./gradlew clean shadowJar
Starting a Gradle Daemon (subsequent builds will be faster)

> Task :flink-tools:compileJava
Note: /home/ubuntu/flink-tools/flink-tools/src/main/java/io/pravega/flinktools/AbstractJob.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 54s
4 actionable tasks: 3 executed, 1 up-to-date
```