### PR TITLE
Bugfix use namespace parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ If you would rather use a more automated deployment method, skip to the next sec
    scripts/flink-image-install.sh
    ```
 
-2. Copy the file `scripts/env-sample.sh` to `scripts/env-local.sh`
-   or any other destination.
+2. Copy the file `scripts/env-sample.sh` to `scripts/env-local.sh`.
    This script will contain parameters for your environment.
    Edit the file as follows.
    

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -14,7 +14,7 @@ ROOT_DIR=$(readlink -f $(dirname $0)/..)
 source ${ROOT_DIR}/scripts/env.sh
 
 # If not specified, get Maven repo parameters using kubectl.
-if [[ $(kubectl get ing -n edge repo -o jsonpath="{.spec.tls}") == "" ]]; then
+if [[ $(kubectl get ing -n ${NAMESPACE} repo -o jsonpath="{.spec.tls}") == "" ]]; then
     export MAVEN_PROTOCOL=http
 else
     export MAVEN_PROTOCOL=https


### PR DESCRIPTION
Update publish.sh to use ${NAMESPACE} variable instead of hard-coded value
Updated README - env-local.sh can only be in the scripts directory - cannot be in any location